### PR TITLE
feat: `x-videodb-client` to display n8n version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1] - 2026-03-17
+
+### Changed
+
+- Updated `x-videodb-client` header to use dynamic version from package.json (`n8n-nodes-videodb/<version>`)
+
 ## [1.1.0] - 2026-01-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You should now be able to search for and use the VideoDB node in your n8n workfl
 
 ## Version history
 
+- 1.1.1 - Updated `x-videodb-client` header to use dynamic version
 - 1.1.0 - Added `Translate Transcript` operation for videos
 - 1.0.9 - Fixed timeline overlay text style parsing; added helpful notice in credentials and UTM tracking
 - 1.0.8 - Explicitly pass `error` message in JSON output when `continueOnFail` is enabled

--- a/credentials/VideoDBApi.credentials.ts
+++ b/credentials/VideoDBApi.credentials.ts
@@ -5,6 +5,8 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
+import { version } from '../package.json';
+
 export class VideoDBApi implements ICredentialType {
 	name = 'videoDBApi';
 	displayName = 'VideoDB API';
@@ -43,7 +45,7 @@ export class VideoDBApi implements ICredentialType {
 		properties: {
 			headers: {
 				'x-access-token': '={{$credentials.apiKey}}',
-				'x-videodb-client': 'videodb-python/0.2.14',
+				'x-videodb-client': `n8n-nodes-videodb/${version}`,
 				'Content-Type': 'application/json',
 			},
 		},
@@ -55,7 +57,7 @@ export class VideoDBApi implements ICredentialType {
 			method: 'GET',
 			headers: {
 				'x-access-token': '={{$credentials.apiKey}}',
-				'x-videodb-client': 'videodb-python/0.2.14',
+				'x-videodb-client': `n8n-nodes-videodb/${version}`,
 				'Content-Type': 'application/json',
 			},
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@videodb/n8n-nodes-videodb",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "An n8n node for VideoDB",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
- fixes the `x-videodb-client` to a `n8n-nodes-videodb/<version>` format